### PR TITLE
Read embedding listen port from env vars

### DIFF
--- a/USEv5_microservice.py
+++ b/USEv5_microservice.py
@@ -5,6 +5,9 @@ from flask import request
 import tensorflow_hub as hub
 
 
+embedding_port = int(os.getenv('EMBEDDING_PORT', 999))
+
+
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 app = flask.Flask('encoder')
@@ -22,4 +25,4 @@ def home():
 if __name__ == '__main__':
     #embed = hub.load("https://tfhub.dev/google/universal-sentence-encoder/4")
     embed = hub.load("https://tfhub.dev/google/universal-sentence-encoder-large/5")  # USEv5 is about 100x faster than 4
-    app.run(host='0.0.0.0', port=999)
+    app.run(host='0.0.0.0', port=embedding_port)


### PR DESCRIPTION
Small change to read the embedding listening port from environment variables instead of hardcoding it.

This small change helps when running the services decoupled (like in containers environments) and at same time is not so intrusive with your work.

Hope it helps.
